### PR TITLE
let users choose which version to use

### DIFF
--- a/components/map/index.js
+++ b/components/map/index.js
@@ -103,7 +103,11 @@ class Map extends Component<MapProps, {mapLoaded: boolean}> {
     };
     if (typeof window !== 'undefined') {
       this.pluginMap = {};
-      this.loader = new APILoader(props.amapkey, props.useAMapUI).load();
+      this.loader = new APILoader({
+        key: props.amapkey,
+        useAMapUI: props.useAMapUI,
+        version: props.version
+      }).load();
     }
   }
 

--- a/components/utils/APILoader.js
+++ b/components/utils/APILoader.js
@@ -15,9 +15,8 @@ let amapuiPromise = null;
 let amapuiInited = false;
 // const queuedLoader = [];
 export default class APILoader {
-  constructor(key, useAMapUI = false) {
-    this.config = DEFAULT_CONFIG;
-    this.config.useAMapUI = useAMapUI;
+  constructor({ key, useAMapUI, version }) {
+    this.config = { ...DEFAULT_CONFIG, ...{ key, useAMapUI, v: version }};
     if (typeof window !== 'undefined') {
       if (key) {
         this.config.key = key;


### PR DESCRIPTION
AMap 1.4.2 has released, with a bunch of new features.
We should be able to explore the new features without waiting for react-amap's new release.