### PR TITLE
get rid of warnings about propTypes and createClass

### DIFF
--- a/components/circle/index.js
+++ b/components/circle/index.js
@@ -1,5 +1,5 @@
 // @flow
-import * as React from 'react';
+import React from 'react';
 import isFun from '../utils/isFun';
 import log from '../utils/log';
 import toCapitalString from '../utils/toCapitalString';

--- a/components/circleeditor/index.js
+++ b/components/circleeditor/index.js
@@ -1,5 +1,5 @@
 // @flow
-import * as React from 'react';
+import React from 'react';
 import log from '../utils/log';
 import isFun from '../utils/isFun';
 

--- a/components/groundimage/index.js
+++ b/components/groundimage/index.js
@@ -1,5 +1,5 @@
 // @flow
-import * as React from 'react';
+import React from 'react';
 import isFun from '../utils/isFun';
 import log from '../utils/log';
 /*

--- a/components/infowindow/index.js
+++ b/components/infowindow/index.js
@@ -1,5 +1,5 @@
 // @flow
-import * as React from 'react';
+import React from 'react';
 import { render } from 'react-dom';
 import isFun from '../utils/isFun';
 import toCapitalString from '../utils/toCapitalString';

--- a/components/map/index.js
+++ b/components/map/index.js
@@ -1,5 +1,5 @@
 // @flow
-import * as React from 'react';
+import React from 'react';
 import APILoader from '../utils/APILoader';
 import isFun from '../utils/isFun';
 import log from '../utils/log';

--- a/components/marker/index.js
+++ b/components/marker/index.js
@@ -1,5 +1,5 @@
 // @flow
-import * as React from 'react';
+import React from 'react';
 import { render } from 'react-dom';
 import log from '../utils/log';
 import isFun from '../utils/isFun';

--- a/components/markers/index.js
+++ b/components/markers/index.js
@@ -1,5 +1,5 @@
 // @flow
-import * as React from 'react';
+import React from 'react';
 import { render } from 'react-dom';
 import isFun from '../utils/isFun';
 import log from '../utils/log';

--- a/components/polyeditor/index.js
+++ b/components/polyeditor/index.js
@@ -1,5 +1,5 @@
 // @flow
-import * as React from 'react';
+import React from 'react';
 import isFun from '../utils/isFun';
 import log from '../utils/log';
 

--- a/components/polyline/index.js
+++ b/components/polyline/index.js
@@ -1,5 +1,5 @@
 // @flow
-import * as React from 'react';
+import React from 'react';
 import isFun from '../utils/isFun';
 import log from '../utils/log';
 import PolyEditor from '../polyeditor';

--- a/flow/common.js
+++ b/flow/common.js
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import * as React from 'react';
+import React from 'react';
 
 declare type AMapLngLat = {
   getLng: Function,


### PR DESCRIPTION
Facebook has extracted propTypes to an independent package since v15.5.

`import * as React from 'react'` will import propTypes as well, which will trigger an annoying warning.
But its fine to use `import * as React from 'react` with React v16, since there's no propTypes on React.
Anyway, it's not necessary to import react like that, `import React from 'react'` should be fine.


#51 