### PR TITLE
fix error: Uncaught (in promise) TypeError: Cannot use 'in' operator …

### DIFF
--- a/components/utils/withPropsReactive.js
+++ b/components/utils/withPropsReactive.js
@@ -91,6 +91,7 @@ function withPropsReactive(MapComponent) {
 
     componentWillUnmount() {
       const { instance } = this.myMapComponent
+      if (!instance) return
       if ('destroy' in instance) {
         instance.destroy()
       }


### PR DESCRIPTION
fix error: Uncaught (in promise) TypeError: Cannot use 'in' operator to search for 'destroy' in undefined

* [x] Make sure you follow the contributing guide.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

当含有地图的组件mout后又很快unmout时，react-amap的组件这时可能还未获得高德地图组件的实例，此时instance为undefined，会造成如标题所示的错误