### PR TITLE
fix: 修复 onInstanceCreated 在 ref 回调之前执行引起的报错

### DIFF
--- a/components/utils/withPropsReactive.js
+++ b/components/utils/withPropsReactive.js
@@ -9,9 +9,14 @@ function withPropsReactive(MapComponent) {
       this.myMapComponent = null
       this.registeredEvents = []
       this.onInstanceCreated = this.onInstanceCreated.bind(this)
+      this.needRunInstanceCreatedCallback = false;
     }
 
     onInstanceCreated() {
+      if (!this.myMapComponent) {
+        this.needRunInstanceCreatedCallback;
+      }
+
       this.instanceCreated = true
       if ('events' in this.props) {
         const { instance } = this.myMapComponent
@@ -38,6 +43,12 @@ function withPropsReactive(MapComponent) {
           })(ev))
         }
       })
+    }
+
+    componentDidMount() {
+      if (this.needRunInstanceCreatedCallback) {
+        this.onInstanceCreated()
+      }
     }
 
     componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
以 Polygon 为例，在 constructor 执行 13ms
之后调用initMapPolygon进而调用onInstanceCreated并不能保证高阶组件中的 ref
回调已经执行，因此执行 onInstanceCreated 时，this.myMapComponent 可能为 null.
因此考虑增加 this.myMapComponent 是否为空的判断，如果为空，则在 didMount
中执行 onInstanceCreated (ref 回调会保证在 didMount 之前执行)
