### PR TITLE
bugfix: Fix the bug in Marker that doesn't support setting the 'label offset' property'

### DIFF
--- a/components/marker/index.js
+++ b/components/marker/index.js
@@ -12,6 +12,8 @@ import {
   toPixel
 } from '../utils/common'
 
+import isObject from '../utils/isObject'
+
 class Marker extends React.Component<MarkerProps, {}> {
 
   map: Object
@@ -134,6 +136,13 @@ class Marker extends React.Component<MarkerProps, {}> {
   getSetterParam(key: string, val: any) {
     if (key in this.converterMap) {
       return this.converterMap[key](val)
+    }
+    if (isObject(val)) {
+      for (let ikey in val) {
+        if (Object.prototype.hasOwnProperty.call(val, ikey)) {
+          val[ikey] = this.getSetterParam(ikey, val[ikey]);
+        }
+      }
     }
     return val
   }

--- a/components/utils/isObject.js
+++ b/components/utils/isObject.js
@@ -1,0 +1,5 @@
+const isObject = (args) => {
+  return !!args && Object.prototype.toString.call(args).slice(8, -1) === 'Object';
+}
+
+export default isObject;


### PR DESCRIPTION
… offset' property.

Please makes sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow the contributing guide.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.

This pr fix a bug described in issue:#252 .

In `Marker`, we set `label.offset` in the following manner, but it does not work as expected. This is because the `converterMap` in the marker does not take the wrapper object into consideration

```code
<Marker position={{longitude: 121, latitude: 36}}
 label={{content: 'This is a test label', offset: [10,10]}} />

```

So I do some changes in the function `getSetterParam`
```code
getSetterParam(key: string, val: any) {
    if (key in this.converterMap) {
      return this.converterMap[key](val)
    }
    if (isObject(val)) {
      for (let ikey in val) {
        if (Object.prototype.hasOwnProperty.call(val, ikey)) {
          val[ikey] = this.getSetterParam(ikey, val[ikey]);
        }
      }
    }
    return val
  }
```